### PR TITLE
Fix wrong inflector behaviour

### DIFF
--- a/src/Inflector.php
+++ b/src/Inflector.php
@@ -436,7 +436,7 @@ final class Inflector
         $regex = $strict
             ? '/(?<=\p{L})(\p{Lu})/u'
             : '/(?<=\p{L})(?<!\p{Lu})(\p{Lu})/u';
-        $result = preg_replace($regex, $separator . '$1', $name);
+        $result = preg_replace($regex, addslashes($separator) . '\1', $name);
 
         if ($separator !== '_') {
             $result = str_replace('_', $separator, $result);

--- a/src/Inflector.php
+++ b/src/Inflector.php
@@ -428,17 +428,21 @@ final class Inflector
      * For example, 'PostTag' will be converted to 'post-tag'.
      * @param string $name the string to be converted
      * @param string $separator the character used to concatenate the words in the ID
-     * @param bool|string $strict whether to insert a separator between two consecutive uppercase chars, defaults to false
+     * @param bool $strict whether to insert a separator between two consecutive uppercase chars, defaults to false
      * @return string the resulting ID
      */
     public function camel2id(string $name, string $separator = '-', bool $strict = false): string
     {
-        $regex = $strict ? '/\p{Lu}/u' : '/(?<!\p{Lu})\p{Lu}/u';
-        if ($separator === '_') {
-            return mb_strtolower(trim(preg_replace($regex, '_\0', $name), '_'));
+        $regex = $strict
+            ? '/(?<=\p{L})(\p{Lu})/u'
+            : '/(?<=\p{L})(?<!\p{Lu})(\p{Lu})/u';
+        $result = preg_replace($regex, $separator . '$1', $name);
+
+        if ($separator !== '_') {
+            $result = str_replace('_', $separator, $result);
         }
 
-        return mb_strtolower(trim(str_replace('_', $separator, preg_replace($regex, $separator . '\0', $name)), $separator));
+        return mb_strtolower(trim($result, $separator));
     }
 
     /**

--- a/tests/InflectorTest.php
+++ b/tests/InflectorTest.php
@@ -103,6 +103,7 @@ final class InflectorTest extends TestCase
      */
     public function testCamel2id(string $expectedResult, array $arguments): void
     {
+
         $inflector = new Inflector();
 
         $result = call_user_func_array([$inflector, 'camel2id'], $arguments);
@@ -433,13 +434,18 @@ final class InflectorTest extends TestCase
     public function camel2idProvider():array
     {
         return [
-            ['photo\\album-controller', ['Photo\\AlbumController']],
-            ['photo\\album\\controller', ['Photo\\Album\\Controller']],
+            ['photo\\album-controller', ['Photo\\AlbumController', '-', false]],
+            ['photo\\album-controller', ['Photo\\AlbumController', '-', true]],
+            ['photo\\album\\controller', ['Photo\\Album\\Controller', '-', false]],
+            ['photo\\album\\controller', ['Photo\\Album\\Controller', '-', true]],
 
-            ['photo\\album_controller', ['Photo\\AlbumController', '_']],
-            ['photo\\album\\controller', ['Photo\\Album\\Controller', '_']],
+            ['photo\\album_controller', ['Photo\\AlbumController', '_', false]],
+            ['photo\\album_controller', ['Photo\\AlbumController', '_', true]],
+            ['photo\\album\\controller', ['Photo\\Album\\Controller', '_', false]],
+            ['photo\\album\\controller', ['Photo\\Album\\Controller', '_', true]],
 
-            ['photo/album/controller', ['Photo/Album/Controller']],
+            ['photo/album/controller', ['Photo/Album/Controller', '-', false]],
+            ['photo/album/controller', ['Photo/Album/Controller', '-', true]],
 
             ['post-tag', ['PostTag']],
             ['post_tag', ['PostTag', '_']],

--- a/tests/InflectorTest.php
+++ b/tests/InflectorTest.php
@@ -440,6 +440,10 @@ final class InflectorTest extends TestCase
 
             ['photo\\album_controller', ['Photo\\AlbumController', '_', false]],
             ['photo\\album_controller', ['Photo\\AlbumController', '_', true]],
+            ['photo\\album\\controller', ['Photo\\AlbumController', '\\', false]],
+            ['photo\\album\\controller', ['Photo\\AlbumController', '\\', true]],
+            ['photo\\album/controller', ['Photo\\AlbumController', '/', false]],
+            ['photo\\album/controller', ['Photo\\AlbumController', '/', true]],
             ['photo\\album\\controller', ['Photo\\Album\\Controller', '_', false]],
             ['photo\\album\\controller', ['Photo\\Album\\Controller', '_', true]],
 

--- a/tests/InflectorTest.php
+++ b/tests/InflectorTest.php
@@ -430,7 +430,7 @@ final class InflectorTest extends TestCase
         self::assertThat($actual, new IsOneOfAssert($expected), $message);
     }
 
-    public function camel2idProvider():array
+    public function camel2idProvider(): array
     {
         return [
             ['photo\\album-controller', ['Photo\\AlbumController']],

--- a/tests/InflectorTest.php
+++ b/tests/InflectorTest.php
@@ -103,7 +103,6 @@ final class InflectorTest extends TestCase
      */
     public function testCamel2id(string $expectedResult, array $arguments): void
     {
-
         $inflector = new Inflector();
 
         $result = call_user_func_array([$inflector, 'camel2id'], $arguments);

--- a/tests/InflectorTest.php
+++ b/tests/InflectorTest.php
@@ -98,44 +98,29 @@ final class InflectorTest extends TestCase
         $this->assertEquals('І Це Дійсно Так!', $inflector->camel2words('ІЦеДійсноТак!'));
     }
 
-    public function testCamel2id(): void
+    /**
+     * @dataProvider camel2idProvider()
+     */
+    public function testCamel2id(string $expectedResult, array $arguments): void
     {
         $inflector = new Inflector();
 
-        $this->assertEquals('post-tag', $inflector->camel2id('PostTag'));
-        $this->assertEquals('post_tag', $inflector->camel2id('PostTag', '_'));
-        $this->assertEquals('єдиний_код', $inflector->camel2id('ЄдинийКод', '_'));
+        $result = call_user_func_array([$inflector, 'camel2id'], $arguments);
 
-        $this->assertEquals('post-tag', $inflector->camel2id('postTag'));
-        $this->assertEquals('post_tag', $inflector->camel2id('postTag', '_'));
-        $this->assertEquals('єдиний_код', $inflector->camel2id('єдинийКод', '_'));
-
-        $this->assertEquals('foo-ybar', $inflector->camel2id('FooYBar', '-', false));
-        $this->assertEquals('foo_ybar', $inflector->camel2id('fooYBar', '_', false));
-        $this->assertEquals('невже_іце_працює', $inflector->camel2id('НевжеІЦеПрацює', '_', false));
-
-        $this->assertEquals('foo-y-bar', $inflector->camel2id('FooYBar', '-', true));
-        $this->assertEquals('foo_y_bar', $inflector->camel2id('fooYBar', '_', true));
-        $this->assertEquals('foo_y_bar', $inflector->camel2id('fooYBar', '_', true));
-        $this->assertEquals('невже_і_це_працює', $inflector->camel2id('НевжеІЦеПрацює', '_', true));
+        $this->assertEquals($expectedResult, $result);
     }
 
-    public function testId2camel(): void
+
+    /**
+     * @dataProvider id2camelProvider()
+     */
+    public function testId2camel(string $expectedResult, array $arguments): void
     {
         $inflector = new Inflector();
 
-        $this->assertEquals('PostTag', $inflector->id2camel('post-tag'));
-        $this->assertEquals('PostTag', $inflector->id2camel('post_tag', '_'));
-        $this->assertEquals('ЄдинийСвіт', $inflector->id2camel('єдиний_світ', '_'));
+        $result = call_user_func_array([$inflector, 'id2camel'], $arguments);
 
-        $this->assertEquals('PostTag', $inflector->id2camel('post-tag'));
-        $this->assertEquals('PostTag', $inflector->id2camel('post_tag', '_'));
-        $this->assertEquals('НевжеІЦеПрацює', $inflector->id2camel('невже_і_це_працює', '_'));
-
-        $this->assertEquals('ShouldNotBecomeLowercased', $inflector->id2camel('ShouldNotBecomeLowercased', '_'));
-
-        $this->assertEquals('FooYBar', $inflector->id2camel('foo-y-bar'));
-        $this->assertEquals('FooYBar', $inflector->id2camel('foo_y_bar', '_'));
+        $this->assertEquals($expectedResult, $result);
     }
 
     public function testHumanize(): void
@@ -443,5 +428,54 @@ final class InflectorTest extends TestCase
     private function assertIsOneOf($actual, array $expected, $message = ''): void
     {
         self::assertThat($actual, new IsOneOfAssert($expected), $message);
+    }
+
+    public function camel2idProvider():array
+    {
+        return [
+            ['photo\\album-controller', ['Photo\\AlbumController']],
+            ['photo\\album\\controller', ['Photo\\Album\\Controller']],
+
+            ['photo\\album_controller', ['Photo\\AlbumController', '_']],
+            ['photo\\album\\controller', ['Photo\\Album\\Controller', '_']],
+
+            ['photo/album/controller', ['Photo/Album/Controller']],
+
+            ['post-tag', ['PostTag']],
+            ['post_tag', ['PostTag', '_']],
+            ['єдиний_код', ['ЄдинийКод', '_']],
+
+            ['post-tag', ['postTag']],
+            ['post_tag', ['postTag', '_']],
+            ['єдиний_код', ['єдинийКод', '_']],
+
+            ['foo-ybar', ['FooYBar', '-', false]],
+            ['foo_ybar', ['fooYBar', '_', false]],
+            ['невже_іце_працює', ['НевжеІЦеПрацює', '_', false]],
+
+            ['foo-y-bar', ['FooYBar', '-', true]],
+            ['foo_y_bar', ['fooYBar', '_', true]],
+            ['foo_y_bar', ['fooYBar', '_', true]],
+            ['невже_і_це_працює', ['НевжеІЦеПрацює', '_', true]],
+
+        ];
+    }
+
+    public function id2camelProvider(): array
+    {
+        return [
+            ['PostTag', ['post-tag']],
+            ['PostTag', ['post_tag', '_']],
+            ['ЄдинийСвіт', ['єдиний_світ', '_']],
+
+            ['PostTag', ['post-tag']],
+            ['PostTag', ['post_tag', '_']],
+            ['НевжеІЦеПрацює', ['невже_і_це_працює', '_']],
+
+            ['ShouldNotBecomeLowercased', ['ShouldNotBecomeLowercased', '_']],
+
+            ['FooYBar', ['foo-y-bar']],
+            ['FooYBar', ['foo_y_bar', '_']],
+        ];
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ✔️
| Breaks BC?    | ❌
| Tests pass?   | ✔️

## Before
```php
echo $inflector->camel2id('User\Controller'); // user\-controller
echo $inflector->camel2id('MyController', '\\'); // my\1controller
```

## After
```php
echo $inflector->camel2id('User\Controller'); // user\controller
echo $inflector->camel2id('MyController', '\\'); // my\controller
```