### PR TITLE
Add WildcardPattern::withEnding()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.0.2 under development
 
+- Enh #51: Add an option `withEnding()` to `WildcardPattern` for match ending of testing string (vjik)
 - Bug #44: `NumericHelper::toOrdinal` throws an error for numbers with fractional part (vjik)
 
 ## 1.0.1 October 12, 2020

--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ Several options are available. Call these before doing a `match()`:
 - `withExactSlashes()` - makes `\` in a string to match `\` only in a pattern. 
 - `ignoreCase()` - case-insensitive match.
 - `withExactLeadingPeriod()` - makes first `.` in a string match only `.` in a pattern.
+- `withEnding()` - match ending of testing string.
 
 When matching file paths, it is advised to use both `withExactSlashes()` and `withExactLeadingPeriod()`:
 

--- a/src/WildcardPattern.php
+++ b/src/WildcardPattern.php
@@ -134,7 +134,8 @@ final class WildcardPattern
     }
 
     /**
-     * Match ending
+     * Match ending only.
+     * By default wildcard pattern matches string exactly. By using this mode, beginning of the string could be anything.
      * @param bool $flag
      * @return self
      */

--- a/src/WildcardPattern.php
+++ b/src/WildcardPattern.php
@@ -27,6 +27,7 @@ final class WildcardPattern
     private bool $matchSlashesExactly = false;
     private bool $matchLeadingPeriodExactly = false;
     private bool $ignoreCase = false;
+    private bool $matchEnding = false;
     private string $pattern;
 
     /**
@@ -77,7 +78,7 @@ final class WildcardPattern
         }
 
         $pattern = strtr(preg_quote($pattern, '#'), $replacements);
-        $pattern = '#^' . $pattern . '$#us';
+        $pattern = '#' . ($this->matchEnding ? '' : '^') . $pattern . '$#us';
 
         if ($this->ignoreCase) {
             $pattern .= 'i';
@@ -129,6 +130,17 @@ final class WildcardPattern
     {
         $new = clone $this;
         $new->matchLeadingPeriodExactly = true;
+        return $new;
+    }
+
+    /**
+     * Match ending
+     * @return self
+     */
+    public function withEnding(): self
+    {
+        $new = clone $this;
+        $new->matchEnding = true;
         return $new;
     }
 }

--- a/src/WildcardPattern.php
+++ b/src/WildcardPattern.php
@@ -135,12 +135,13 @@ final class WildcardPattern
 
     /**
      * Match ending
+     * @param bool $flag
      * @return self
      */
-    public function withEnding(): self
+    public function withEnding(bool $flag = true): self
     {
         $new = clone $this;
-        $new->matchEnding = true;
+        $new->matchEnding = $flag;
         return $new;
     }
 }

--- a/tests/WildcardPatternTest.php
+++ b/tests/WildcardPatternTest.php
@@ -132,6 +132,14 @@ final class WildcardPatternTest extends TestCase
         return $wildcardPattern;
     }
 
+    public function testDisableOptions(): void
+    {
+        $wildcardPattern = (new WildcardPattern('abc'))
+            ->withEnding()
+            ->withEnding(false);
+        $this->assertFalse($wildcardPattern->match('42abc'));
+    }
+
     public function testImmutability(): void
     {
         $original = new WildcardPattern('*');

--- a/tests/WildcardPatternTest.php
+++ b/tests/WildcardPatternTest.php
@@ -86,6 +86,13 @@ final class WildcardPatternTest extends TestCase
             ['begin\*\end', 'begin\end', false, ['escape' => false]],
             ['begin\*\end', 'begin\middle\end', true, ['filePath' => true, 'escape' => false]],
             ['begin\*\end', 'begin\two\steps\end', false, ['filePath' => true, 'escape' => false]],
+            // ending
+            ['i/*.jpg', 'i/hello.jpg', true, ['ending' => true]],
+            ['i/*.jpg', 'i/hello.jpg', true, ['ending' => true, 'filePath' => true]],
+            ['i/*.jpg', 'i/h/hello.jpg', true, ['ending' => true]],
+            ['i/*.jpg', 'i/h/hello.jpg', false, ['ending' => true, 'filePath' => true]],
+            ['i/*.jpg', 'path/to/i/hello.jpg', true, ['ending' => true]],
+            ['i/*.jpg', 'path/to/i/hello.jpg', true, ['ending' => true, 'filePath' => true]],
         ];
     }
 
@@ -118,6 +125,9 @@ final class WildcardPatternTest extends TestCase
         if (isset($options['leadingPeriod']) && $options['leadingPeriod'] === true) {
             $wildcardPattern = $wildcardPattern->withExactLeadingPeriod();
         }
+        if (isset($options['ending']) && $options['ending'] === true) {
+            $wildcardPattern = $wildcardPattern->withEnding();
+        }
 
         return $wildcardPattern;
     }
@@ -129,5 +139,6 @@ final class WildcardPatternTest extends TestCase
         $this->assertNotSame($original, $original->ignoreCase());
         $this->assertNotSame($original, $original->withExactSlashes());
         $this->assertNotSame($original, $original->withoutEscape());
+        $this->assertNotSame($original, $original->withEnding());
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
| Fixed issues  | -

Need this for use in `yiisoft/files` for match paths.

Example of use:

```php
$wildcardPattern = (new WildcardPattern('i/*.jpg'))
	->withExactSlashes()
	->withEnding();
$wildcardPattern->match('path/to/i/hello.jpg'); // true;
$wildcardPattern->match('path/to/i/other/hello.jpg'); // false;
```