### PR TITLE
Add StringHelper::extractLines()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 
 ## 1.1.1 under development
 
-- no changes in this release.
+- Enh #62: Add method `StringHelper::extractLines` that split a string to array with non-empty lines.
 
 ## 1.1.0 November 13, 2020
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 
 ## 1.1.1 under development
 
-- Enh #62: Add method `StringHelper::extractLines` that split a string to array with non-empty lines (vjik)
+- Enh #62: Add method `StringHelper::split` that split a string to array with non-empty lines (vjik)
 
 ## 1.1.0 November 13, 2020
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 
 ## 1.1.1 under development
 
-- Enh #62: Add method `StringHelper::extractLines` that split a string to array with non-empty lines.
+- Enh #62: Add method `StringHelper::extractLines` that split a string to array with non-empty lines (vjik)
 
 ## 1.1.0 November 13, 2020
 

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Overall the helper has the following method groups.
 
 ### Other
 
-- extractLines
+- split
 
 ## NumericHelper usage
 

--- a/README.md
+++ b/README.md
@@ -81,6 +81,10 @@ Overall the helper has the following method groups.
 - base64UrlEncode
 - base64UrlDecode
 
+### Other
+
+- extractLines
+
 ## NumericHelper usage
 
 Numeric helper methods are static so usage is like the following:

--- a/composer.json
+++ b/composer.json
@@ -21,10 +21,10 @@
         "ext-mbstring": "*"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.4",
-        "roave/infection-static-analysis-plugin": "^1.5",
+        "phpunit/phpunit": "^9.5",
+        "roave/infection-static-analysis-plugin": "^1.6",
         "spatie/phpunit-watcher": "^1.23",
-        "vimeo/psalm": "^4.2"
+        "vimeo/psalm": "^4.3"
     },
     "autoload": {
         "psr-4": {

--- a/src/StringHelper.php
+++ b/src/StringHelper.php
@@ -479,12 +479,13 @@ final class StringHelper
      * Whitespace from the beginning and end of a each line will be stripped.
      *
      * @param string $string The input string.
+     * @param string $separator The boundary string.
      *
      * @return array
      */
-    public static function split(string $string): array
+    public static function split(string $string, string $separator = '\R'): array
     {
         $string = preg_replace('(^\s*|\s*$)', '', $string);
-        return preg_split('~\s*\R\s*~', $string, -1, PREG_SPLIT_NO_EMPTY);
+        return preg_split('~\s*' . $separator . '\s*~', $string, -1, PREG_SPLIT_NO_EMPTY);
     }
 }

--- a/src/StringHelper.php
+++ b/src/StringHelper.php
@@ -476,17 +476,15 @@ final class StringHelper
 
     /**
      * Split a string to array with non-empty lines.
-     * Whitespace from the beginning and end of a each line will be stripped by using {@see trim()}.
+     * Whitespace from the beginning and end of a each line will be stripped.
      *
      * @param string $string The input string.
      *
      * @return array
      */
-    public static function extractLines(string $string): array
+    public static function split(string $string): array
     {
-        $lines = preg_split('~(\r\n|\n\r|\n|\r)~', $string, -1, PREG_SPLIT_NO_EMPTY);
-        $lines = array_map('trim', $lines);
-        $lines = array_filter($lines, fn ($line) => $line !== '');
-        return array_values($lines);
+        $string = preg_replace('(^\s*|\s*$)', '', $string);
+        return preg_split('~\s*\R\s*~', $string, -1, PREG_SPLIT_NO_EMPTY);
     }
 }

--- a/src/StringHelper.php
+++ b/src/StringHelper.php
@@ -475,7 +475,7 @@ final class StringHelper
     }
 
     /**
-     * Split a string to array with non empty lines.
+     * Split a string to array with non-empty lines.
      * Whitespace from the beginning and end of a each line will be stripped by using {@see trim()}.
      *
      * @param string $string The input string.

--- a/src/StringHelper.php
+++ b/src/StringHelper.php
@@ -473,4 +473,20 @@ final class StringHelper
     {
         return base64_decode(strtr($input, '-_', '+/'));
     }
+
+    /**
+     * Split a string to array with non empty lines.
+     * Whitespace from the beginning and end of a each line will be stripped by using {@see trim()}.
+     *
+     * @param string $string The input string.
+     *
+     * @return array
+     */
+    public static function extractLines(string $string): array
+    {
+        $lines = preg_split('~(\r\n|\n\r|\n|\r)~', $string, -1, PREG_SPLIT_NO_EMPTY);
+        $lines = array_map('trim', $lines);
+        $lines = array_filter($lines, fn ($line) => $line !== '');
+        return array_values($lines);
+    }
 }

--- a/src/StringHelper.php
+++ b/src/StringHelper.php
@@ -479,7 +479,8 @@ final class StringHelper
      * Whitespace from the beginning and end of a each line will be stripped.
      *
      * @param string $string The input string.
-     * @param string $separator The boundary string.
+     * @param string $separator The boundary string. It is a part of regular expression
+     * so should be taken into account or properly escaped with {@see preg_quote()}.
      *
      * @return array
      */

--- a/tests/StringHelperTest.php
+++ b/tests/StringHelperTest.php
@@ -416,4 +416,9 @@ final class StringHelperTest extends TestCase
     {
         $this->assertSame($expected, StringHelper::split($string));
     }
+
+    public function testSplitWithSeparator(): void
+    {
+        $this->assertSame(['A', 'B', 'C'], StringHelper::split(' A 2 B3C', '\d'));
+    }
 }

--- a/tests/StringHelperTest.php
+++ b/tests/StringHelperTest.php
@@ -368,11 +368,17 @@ final class StringHelperTest extends TestCase
         $this->assertSame($expected, StringHelper::replaceSubstring(...$arguments));
     }
 
-    public function dataExtractLines(): array
+    public function dataSplit(): array
     {
         return [
             ['', []],
             [' ', []],
+            [" \n\n \n ", []],
+            [' A B', ['A B']],
+            ['A B ', ['A B']],
+            ['A B', ['A B']],
+            ['Home', ['Home']],
+            [' Hello World! ', ['Hello World!']],
             [
                 "A \r B \r\r \r C",
                 ['A', 'B', 'C'],
@@ -382,24 +388,24 @@ final class StringHelperTest extends TestCase
                 ['A', 'B', 'C'],
             ],
             [
-                "A \n\r B \n\r\n\r \n\r C",
+                "A \r\n B \r\n\r\n \r\n C",
                 ['A', 'B', 'C'],
             ],
             [
-                "A \r\n B \r\n\r\n \r\n C",
-                ['A', 'B', 'C'],
+                "A \n Hello World! \n \n C",
+                ['A', 'Hello World!', 'C'],
             ],
         ];
     }
 
     /**
-     * @dataProvider dataExtractLines
+     * @dataProvider dataSplit
      *
      * @param string $string
      * @param array $expected
      */
-    public function testExtractLines(string $string, array $expected): void
+    public function testSplit(string $string, array $expected): void
     {
-        $this->assertSame($expected, StringHelper::extractLines($string));
+        $this->assertSame($expected, StringHelper::split($string));
     }
 }

--- a/tests/StringHelperTest.php
+++ b/tests/StringHelperTest.php
@@ -375,19 +375,19 @@ final class StringHelperTest extends TestCase
             [' ', []],
             [
                 "A \r B \r\r \r C",
-                ['A', 'B', 'C']
+                ['A', 'B', 'C'],
             ],
             [
                 "A \n B \n\n \n C",
-                ['A', 'B', 'C']
+                ['A', 'B', 'C'],
             ],
             [
                 "A \n\r B \n\r\n\r \n\r C",
-                ['A', 'B', 'C']
+                ['A', 'B', 'C'],
             ],
             [
                 "A \r\n B \r\n\r\n \r\n C",
-                ['A', 'B', 'C']
+                ['A', 'B', 'C'],
             ],
         ];
     }

--- a/tests/StringHelperTest.php
+++ b/tests/StringHelperTest.php
@@ -367,4 +367,39 @@ final class StringHelperTest extends TestCase
     {
         $this->assertSame($expected, StringHelper::replaceSubstring(...$arguments));
     }
+
+    public function dataExtractLines(): array
+    {
+        return [
+            ['', []],
+            [' ', []],
+            [
+                "A \r B \r\r \r C",
+                ['A', 'B', 'C']
+            ],
+            [
+                "A \n B \n\n \n C",
+                ['A', 'B', 'C']
+            ],
+            [
+                "A \n\r B \n\r\n\r \n\r C",
+                ['A', 'B', 'C']
+            ],
+            [
+                "A \r\n B \r\n\r\n \r\n C",
+                ['A', 'B', 'C']
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider dataExtractLines
+     *
+     * @param string $string
+     * @param array $expected
+     */
+    public function testExtractLines(string $string, array $expected): void
+    {
+        $this->assertSame($expected, StringHelper::extractLines($string));
+    }
 }

--- a/tests/StringHelperTest.php
+++ b/tests/StringHelperTest.php
@@ -401,8 +401,8 @@ final class StringHelperTest extends TestCase
             ],
             [
                 "\0\nA\nB",
-                ["\0", 'A', 'B']
-            ]
+                ["\0", 'A', 'B'],
+            ],
         ];
     }
 

--- a/tests/StringHelperTest.php
+++ b/tests/StringHelperTest.php
@@ -392,9 +392,17 @@ final class StringHelperTest extends TestCase
                 ['A', 'B', 'C'],
             ],
             [
+                "A \v B \v \v C",
+                ['A', 'B', 'C'],
+            ],
+            [
                 "A \n Hello World! \n \n C",
                 ['A', 'Hello World!', 'C'],
             ],
+            [
+                "\0\nA\nB",
+                ["\0", 'A', 'B']
+            ]
         ];
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
| Fixed issues  | -

`StringHelper::extractLines()` split a string to array with non empty lines. Whitespace from the beginning and end of a each line will be stripped by using `trim()`.