### PR TITLE
Add support of a boolean values to NumericHelper::normalize()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ## 1.1.1 under development
 
 - Enh #62: Add method `StringHelper::split` that split a string to array with non-empty lines (vjik)
+- Enh #64: Add support of a boolean values to `NumericHelper::normalize` (vjik) 
 
 ## 1.1.0 November 13, 2020
 

--- a/src/NumericHelper.php
+++ b/src/NumericHelper.php
@@ -47,7 +47,7 @@ final class NumericHelper
     /**
      * Returns string representation of a number value without thousands separators and with dot as decimal separator.
      *
-     * @param float|int|string|bool $value
+     * @param bool|float|int|string $value
      *
      * @throws InvalidArgumentException if value is not scalar.
      *

--- a/src/NumericHelper.php
+++ b/src/NumericHelper.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Yiisoft\Strings;
 
+use InvalidArgumentException;
+
 /**
  * Provides static methods to work with numeric strings.
  */
@@ -20,7 +22,7 @@ final class NumericHelper
     {
         if (!is_numeric($value)) {
             $type = gettype($value);
-            throw new \InvalidArgumentException("Value must be numeric. $type given.");
+            throw new InvalidArgumentException("Value must be numeric. $type given.");
         }
 
         if (fmod((float)$value, 1) !== 0.00) {
@@ -45,20 +47,26 @@ final class NumericHelper
     /**
      * Returns string representation of a number value without thousands separators and with dot as decimal separator.
      *
-     * @param float|int|string $value
+     * @param float|int|string|bool $value
+     *
+     * @throws InvalidArgumentException if value is not scalar.
      *
      * @return string
      */
     public static function normalize($value): string
     {
-        /**
-         * @psalm-suppress DocblockTypeContradiction
-         */
+        /** @psalm-suppress DocblockTypeContradiction */
         if (!is_scalar($value)) {
             $type = gettype($value);
-            throw new \InvalidArgumentException("Value must be scalar. $type given.");
+            throw new InvalidArgumentException("Value must be scalar. $type given.");
         }
-        $value = str_replace([' ', ','], ['', '.'], (string)$value);
+
+        if (is_bool($value)) {
+            $value = $value ? '1' : '0';
+        } else {
+            $value = (string)$value;
+        }
+        $value = str_replace([' ', ','], ['', '.'], $value);
         return preg_replace('/\.(?=.*\.)/', '', $value);
     }
 }

--- a/tests/NumericHelperTest.php
+++ b/tests/NumericHelperTest.php
@@ -37,7 +37,7 @@ final class NumericHelperTest extends TestCase
         NumericHelper::toOrdinal('bla-bla');
     }
 
-    public function normalizeNumberDataProvider(): array
+    public function dataNormalize(): array
     {
         return [
             'French' => ['4 294 967 295,000', '4294967295.000'],
@@ -47,21 +47,23 @@ final class NumericHelperTest extends TestCase
             'Smaller' => ['10,111', '10.111'],
             'Float' => [10.01, '10.01'],
             'Int' => [10, '10'],
+            'True' => [true, '1'],
+            'False' => [false, '0'],
         ];
     }
 
     /**
-     * @dataProvider normalizeNumberDataProvider
+     * @dataProvider dataNormalize
      *
      * @param float|int|string $input
      * @param string $expected
      */
-    public function testNormalizeNumber($input, string $expected): void
+    public function testNormalize($input, string $expected): void
     {
         $this->assertSame($expected, NumericHelper::normalize($input));
     }
 
-    public function testNormalizeNumberWithIncorrectType(): void
+    public function testNormalizeWithIncorrectType(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         NumericHelper::normalize([]);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ✔️
| Fixed issues  | -

```php
// before this PR
NumericHelper::normalize(true); // "1"
NumericHelper::normalize(false); // empty string

// after this PR
NumericHelper::normalize(true); // "1"
NumericHelper::normalize(false); // "0"
```