### PR TITLE
Add stringable object support to `NumericHelper::normalize()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 2.2.1 under development
 
-- no changes in this release.
+- Enh #114: Add stringable object support to `NumericHelper::normalize()` (@vjik)
 
 ## 2.2.0 September 20, 2023
 

--- a/src/NumericHelper.php
+++ b/src/NumericHelper.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Yiisoft\Strings;
 
 use InvalidArgumentException;
+use Stringable;
 
 use function filter_var;
 use function fmod;
@@ -52,14 +53,14 @@ final class NumericHelper
     /**
      * Returns string representation of a number value without thousands separators and with dot as decimal separator.
      *
-     * @param bool|float|int|string $value
+     * @param bool|float|int|string|Stringable $value
      *
      * @throws InvalidArgumentException if value is not scalar.
      */
     public static function normalize(mixed $value): string
     {
         /** @psalm-suppress DocblockTypeContradiction */
-        if (!is_scalar($value)) {
+        if (!is_scalar($value) && !$value instanceof Stringable) {
             $type = gettype($value);
             throw new InvalidArgumentException("Value must be scalar. $type given.");
         }

--- a/tests/NumericHelperTest.php
+++ b/tests/NumericHelperTest.php
@@ -6,6 +6,7 @@ namespace Yiisoft\Strings\Tests;
 
 use PHPUnit\Framework\TestCase;
 use Yiisoft\Strings\NumericHelper;
+use Yiisoft\Strings\Tests\Support\StringableObject;
 
 final class NumericHelperTest extends TestCase
 {
@@ -49,6 +50,7 @@ final class NumericHelperTest extends TestCase
             'Int' => [10, '10'],
             'True' => [true, '1'],
             'False' => [false, '0'],
+            'Stringable' => [new StringableObject('test'), 'test'],
         ];
     }
 

--- a/tests/Support/StringableObject.php
+++ b/tests/Support/StringableObject.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Strings\Tests\Support;
+
+use Stringable;
+
+final class StringableObject implements Stringable
+{
+    public function __construct(
+        private string $string
+    ) {
+    }
+
+    public function __toString(): string
+    {
+        return $this->string;
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
| Fixed issues  | -