### PR TITLE
Implement `findBetween()`, `findBetweenFirst()`, and `findBetweenLast()` Methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@
 ## 2.3.1 October 30, 2023
 
 - Enh #117: `WildcardPatters` uses memoization and accelerates ~2 times on repeated calls (@viktorprogger)
-- Enh #118: Added `findBetween()`, `findBetweenFirst()` and `findBetweenLast()` methods to `StringHelper` to retrieve a substring that lies between two strings (salehhashemi1992)
+- Enh #118: Added `findBetween()`, `findBetweenFirst()` and `findBetweenLast()` methods to `StringHelper` to retrieve
+  a substring that lies between two strings (@salehhashemi1992)
 
 ## 2.3.0 October 23, 2023
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,13 @@
 # Yii Strings Change Log
 
-## 2.3.2 under development
+## 2.4.0 under development
 
-- no changes in this release.
+- New #118: Add `findBetween()`, `findBetweenFirst()` and `findBetweenLast()` methods to `StringHelper` to retrieve
+  a substring that lies between two strings (@salehhashemi1992)
 
 ## 2.3.1 October 30, 2023
 
 - Enh #117: `WildcardPatters` uses memoization and accelerates ~2 times on repeated calls (@viktorprogger)
-- New #118: Add `findBetween()`, `findBetweenFirst()` and `findBetweenLast()` methods to `StringHelper` to retrieve
-  a substring that lies between two strings (@salehhashemi1992)
 
 ## 2.3.0 October 23, 2023
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ## 2.3.1 October 30, 2023
 
 - Enh #117: `WildcardPatters` uses memoization and accelerates ~2 times on repeated calls (@viktorprogger)
+- Enh #118: Added yii\helpers\BaseStringHelper::findBetween() to retrieve a substring that lies between two strings (salehhashemi1992)
 
 ## 2.3.0 October 23, 2023
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 ## 2.3.1 October 30, 2023
 
 - Enh #117: `WildcardPatters` uses memoization and accelerates ~2 times on repeated calls (@viktorprogger)
-- Enh #118: Added yii\helpers\BaseStringHelper::findBetween() to retrieve a substring that lies between two strings (salehhashemi1992)
+- Enh #118: Added `findBetween()`, `findBetweenFirst()` and `findBetweenLast()` methods to `StringHelper` to retrieve a substring that lies between two strings (salehhashemi1992)
 
 ## 2.3.0 October 23, 2023
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 ## 2.3.1 October 30, 2023
 
 - Enh #117: `WildcardPatters` uses memoization and accelerates ~2 times on repeated calls (@viktorprogger)
-- Enh #118: Added `findBetween()`, `findBetweenFirst()` and `findBetweenLast()` methods to `StringHelper` to retrieve
+- New #118: Add `findBetween()`, `findBetweenFirst()` and `findBetweenLast()` methods to `StringHelper` to retrieve
   a substring that lies between two strings (@salehhashemi1992)
 
 ## 2.3.0 October 23, 2023

--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ Overall the helper has the following method groups.
 - startsWithIgnoringCase
 - endsWith
 - endsWithIgnoringCase
+- findBetween
 
 ### Truncation
 

--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ Overall the helper has the following method groups.
 - endsWith
 - endsWithIgnoringCase
 - findBetween
+- findBetweenFirst
+- findBetweenLast
 
 ### Truncation
 

--- a/src/StringHelper.php
+++ b/src/StringHelper.php
@@ -637,15 +637,14 @@ final class StringHelper
             return null;
         }
 
-        // Cut the string from the start position
-        $subString = mb_substr($string, $startPos + mb_strlen($start));
-        $endPos = mb_strrpos($subString, $end);
+        $startPos += mb_strlen($start);
+        $endPos = mb_strrpos($string, $end, $startPos);
 
         if ($endPos === false) {
             return null;
         }
 
-        return mb_substr($subString, 0, $endPos);
+        return mb_substr($string, $startPos, $endPos - $startPos);
     }
 
     /**

--- a/src/StringHelper.php
+++ b/src/StringHelper.php
@@ -620,17 +620,22 @@ final class StringHelper
     }
 
     /**
-     * Returns the portion of the string that lies between the first occurrence of the start string
-     * and the last occurrence of the end string after that.
+     * Returns the portion of the string that lies between the first occurrence of the `$start` string
+     * and the last occurrence of the `$end` string after that.
      *
      * @param string $string The input string.
      * @param string $start The string marking the start of the portion to extract.
-     * @param string $end The string marking the end of the portion to extract.
+     * @param string|null $end The string marking the end of the portion to extract.
+     * If the `$end` string is not provided, it defaults to the value of the `$start` string.
      * @return string|null The portion of the string between the first occurrence of
-     * start and the last occurrence of end, or null if either start or end cannot be found.
+     * `$start` and the last occurrence of `$end`, or null if either `$start` or `$end` cannot be found.
      */
-    public static function findBetween(string $string, string $start, string $end): ?string
+    public static function findBetween(string $string, string $start, ?string $end = null): ?string
     {
+        if ($end === null) {
+            $end = $start;
+        }
+
         $startPos = mb_strpos($string, $start);
 
         if ($startPos === false) {
@@ -648,16 +653,21 @@ final class StringHelper
     }
 
     /**
-     * Returns the portion of the string between the initial occurrence of the 'start' string
-     * and the next occurrence of the 'end' string.
+     * Returns the portion of the string between the initial occurrence of the '$start' string
+     * and the next occurrence of the '$end' string.
      *
      * @param string $string The input string.
      * @param string $start The string marking the beginning of the segment to extract.
-     * @param string $end The string marking the termination of the segment.
-     * @return string|null Extracted segment, or null if 'start' or 'end' is not present.
+     * @param string|null $end The string marking the termination of the segment.
+     * If the '$end' string is not provided, it defaults to the value of the '$start' string.
+     * @return string|null Extracted segment, or null if '$start' or '$end' is not present.
      */
-    public static function findBetweenFirst(string $string, string $start, string $end): ?string
+    public static function findBetweenFirst(string $string, string $start, ?string $end = null): ?string
     {
+        if ($end === null) {
+            $end = $start;
+        }
+
         $startPos = mb_strpos($string, $start);
 
         if ($startPos === false) {
@@ -675,16 +685,21 @@ final class StringHelper
     }
 
     /**
-     * Returns the portion of the string between the latest 'start' string
-     * and the subsequent 'end' string.
+     * Returns the portion of the string between the latest '$start' string
+     * and the subsequent '$end' string.
      *
      * @param string $string The input string.
      * @param string $start The string marking the beginning of the segment to extract.
-     * @param string $end The string marking the termination of the segment.
-     * @return string|null Extracted segment, or null if 'start' or 'end' is not present.
+     * @param string|null $end The string marking the termination of the segment.
+     * If the '$end' string is not provided, it defaults to the value of the '$start' string.
+     * @return string|null Extracted segment, or null if '$start' or '$end' is not present.
      */
-    public static function findBetweenLast(string $string, string $start, string $end): ?string
+    public static function findBetweenLast(string $string, string $start, ?string $end = null): ?string
     {
+        if ($end === null) {
+            $end = $start;
+        }
+
         $endPos = mb_strrpos($string, $end);
 
         if ($endPos === false) {

--- a/src/StringHelper.php
+++ b/src/StringHelper.php
@@ -620,6 +620,35 @@ final class StringHelper
     }
 
     /**
+     * Returns the portion of the string that lies between the first occurrence of the start string
+     * and the last occurrence of the end string after that.
+     *
+     * @param string $string The input string.
+     * @param string $start The string marking the start of the portion to extract.
+     * @param string $end The string marking the end of the portion to extract.
+     * @return string|null The portion of the string between the first occurrence of
+     * start and the last occurrence of end, or null if either start or end cannot be found.
+     */
+    public static function findBetween(string $string, string $start, string $end): ?string
+    {
+        $startPos = mb_strpos($string, $start);
+
+        if ($startPos === false) {
+            return null;
+        }
+
+        // Cut the string from the start position
+        $subString = mb_substr($string, $startPos + mb_strlen($start));
+        $endPos = mb_strrpos($subString, $end);
+
+        if ($endPos === false) {
+            return null;
+        }
+
+        return mb_substr($subString, 0, $endPos);
+    }
+
+    /**
      * Ensure the input string is a valid UTF-8 string.
      *
      * @param string $pattern The input string.

--- a/src/StringHelper.php
+++ b/src/StringHelper.php
@@ -648,6 +648,61 @@ final class StringHelper
     }
 
     /**
+     * Returns the portion of the string between the initial occurrence of the 'start' string
+     * and the next occurrence of the 'end' string.
+     *
+     * @param string $string The input string.
+     * @param string $start The string marking the beginning of the segment to extract.
+     * @param string $end The string marking the termination of the segment.
+     * @return string|null Extracted segment, or null if 'start' or 'end' is not present.
+     */
+    public static function findBetweenFirst(string $string, string $start, string $end): ?string
+    {
+        $startPos = mb_strpos($string, $start);
+
+        if ($startPos === false) {
+            return null;
+        }
+
+        $startPos += mb_strlen($start);
+        $endPos = mb_strpos($string, $end, $startPos);
+
+        if ($endPos === false) {
+            return null;
+        }
+
+        return mb_substr($string, $startPos, $endPos - $startPos);
+    }
+
+    /**
+     * Returns the portion of the string between the latest 'start' string
+     * and the subsequent 'end' string.
+     *
+     * @param string $string The input string.
+     * @param string $start The string marking the beginning of the segment to extract.
+     * @param string $end The string marking the termination of the segment.
+     * @return string|null Extracted segment, or null if 'start' or 'end' is not present.
+     */
+    public static function findBetweenLast(string $string, string $start, string $end): ?string
+    {
+        $endPos = mb_strrpos($string, $end);
+
+        if ($endPos === false) {
+            return null;
+        }
+
+        $startPos = mb_strrpos(mb_substr($string, 0, $endPos), $start);
+
+        if ($startPos === false) {
+            return null;
+        }
+
+        $startPos += mb_strlen($start);
+
+        return mb_substr($string, $startPos, $endPos - $startPos);
+    }
+
+    /**
      * Ensure the input string is a valid UTF-8 string.
      *
      * @param string $pattern The input string.

--- a/tests/StringHelperTest.php
+++ b/tests/StringHelperTest.php
@@ -767,7 +767,7 @@ final class StringHelperTest extends TestCase
     /**
      * @dataProvider dataProviderFindBetween
      */
-    public function testFindBetween(string $string, string $start, string $end, ?string $expectedResult): void
+    public function testFindBetween(string $string, string $start, ?string $end, ?string $expectedResult): void
     {
         $this->assertSame($expectedResult, StringHelper::findBetween($string, $start, $end));
     }
@@ -786,6 +786,7 @@ final class StringHelperTest extends TestCase
             ['start only', 'start', 'end', null], // start found but no end
             ['end only', 'start', 'end', null], // end found but no start
             ['a1a2a3a', 'a', 'a', '1a2a3'], // same start and end
+            ['a1a2a3a', 'a', null, '1a2a3'], // end is null
             ['spécial !@#$%^&*()', 'spé', '&*()', 'cial !@#$%^'],  // Special characters
             ['من صالح هاشمی هستم', 'من ', ' هستم', 'صالح هاشمی'], // other languages
         ];
@@ -794,7 +795,7 @@ final class StringHelperTest extends TestCase
     /**
      * @dataProvider dataProviderFindBetweenFirst
      */
-    public function testFindBetweenFirst(string $string, string $start, string $end, ?string $expectedResult): void
+    public function testFindBetweenFirst(string $string, string $start, ?string $end, ?string $expectedResult): void
     {
         $this->assertSame($expectedResult, StringHelper::findBetweenFirst($string, $start, $end));
     }
@@ -815,6 +816,7 @@ final class StringHelperTest extends TestCase
             ['start only', 'start', 'end', null], // start found but no end
             ['end only', 'start', 'end', null], // end found but no start
             ['a1a2a3a', 'a', 'a', '1'], // same start and end
+            ['a1a2a3a', 'a', null, '1'], // end is null
             ['spécial !@#$%^&*()', 'spé', '&*()', 'cial !@#$%^'],  // Special characters
             ['من صالح هاشمی هستم هستم', 'من ', ' هستم', 'صالح هاشمی'], // other languages
         ];
@@ -823,7 +825,7 @@ final class StringHelperTest extends TestCase
     /**
      * @dataProvider dataProviderFindBetweenLast
      */
-    public function testFindBetweenLast(string $string, string $start, string $end, ?string $expectedResult): void
+    public function testFindBetweenLast(string $string, string $start, ?string $end, ?string $expectedResult): void
     {
         $this->assertSame($expectedResult, StringHelper::findBetweenLast($string, $start, $end));
     }
@@ -844,6 +846,7 @@ final class StringHelperTest extends TestCase
             ['start only', 'start', 'end', null], // start found but no end
             ['end only', 'start', 'end', null], // end found but no start
             ['a1a2a3a', 'a', 'a', '3'], // same start and end
+            ['a1a2a3a', 'a', null, '3'], // end is null
             ['spécial !@#$%^&*()', 'spé', '&*()', 'cial !@#$%^'],  // Special characters
             ['من صالح هاشمی هستم هستم', 'من ', ' هستم', 'صالح هاشمی هستم'], // other languages
         ];

--- a/tests/StringHelperTest.php
+++ b/tests/StringHelperTest.php
@@ -785,8 +785,67 @@ final class StringHelperTest extends TestCase
             ['no delimiters here', 'start', 'end', null],  // no start and end
             ['start only', 'start', 'end', null], // start found but no end
             ['end only', 'start', 'end', null], // end found but no start
+            ['a1a2a3a', 'a', 'a', '1a2a3'], // same start and end
             ['spécial !@#$%^&*()', 'spé', '&*()', 'cial !@#$%^'],  // Special characters
             ['من صالح هاشمی هستم', 'من ', ' هستم', 'صالح هاشمی'], // other languages
+        ];
+    }
+
+    /**
+     * @dataProvider dataProviderFindBetweenFirst
+     */
+    public function testFindBetweenFirst(string $string, string $start, string $end, ?string $expectedResult): void
+    {
+        $this->assertSame($expectedResult, StringHelper::findBetweenFirst($string, $start, $end));
+    }
+
+    public function dataProviderFindBetweenFirst(): array
+    {
+        return [
+            ['[a][b][c]', '[', ']', 'a'], // normal case
+            ['[a]m[b]n[c]', '[', ']', 'a'], // normal case
+            ['hello world hello', ' hello', ' world', null],  // end before start
+            ['This is a sample string string', ' is ', ' string', 'a sample'],  // normal case
+            ['startendstartend', 'start', 'end', ''],  // end before start
+            ['startmiddleend', 'start', 'end', 'middle'],  // normal case
+            ['startend', 'start', 'end', ''],  // end immediately follows start
+            ['multiple start start end end', 'start ', ' end', 'start'],  // multiple starts and ends
+            ['', 'start', 'end', null],  // empty string
+            ['no delimiters here', 'start', 'end', null],  // no start and end
+            ['start only', 'start', 'end', null], // start found but no end
+            ['end only', 'start', 'end', null], // end found but no start
+            ['a1a2a3a', 'a', 'a', '1'], // same start and end
+            ['spécial !@#$%^&*()', 'spé', '&*()', 'cial !@#$%^'],  // Special characters
+            ['من صالح هاشمی هستم هستم', 'من ', ' هستم', 'صالح هاشمی'], // other languages
+        ];
+    }
+
+    /**
+     * @dataProvider dataProviderFindBetweenLast
+     */
+    public function testFindBetweenLast(string $string, string $start, string $end, ?string $expectedResult): void
+    {
+        $this->assertSame($expectedResult, StringHelper::findBetweenLast($string, $start, $end));
+    }
+
+    public function dataProviderFindBetweenLast(): array
+    {
+        return [
+            ['[a][b][c]', '[', ']', 'c'], // normal case
+            ['[a]m[b]n[c]', '[', ']', 'c'], // normal case
+            ['hello world hello', ' hello', ' world', null],  // end before start
+            ['This is is a sample string string', ' is ', ' string', 'a sample string'],  // normal case
+            ['startendstartend', 'start', 'end', ''],  // end before start
+            ['startmiddleend', 'start', 'end', 'middle'],  // normal case
+            ['startend', 'start', 'end', ''],  // end immediately follows start
+            ['multiple start start end end', 'start ', ' end', 'end'],  // multiple starts and ends
+            ['', 'start', 'end', null],  // empty string
+            ['no delimiters here', 'start', 'end', null],  // no start and end
+            ['start only', 'start', 'end', null], // start found but no end
+            ['end only', 'start', 'end', null], // end found but no start
+            ['a1a2a3a', 'a', 'a', '3'], // same start and end
+            ['spécial !@#$%^&*()', 'spé', '&*()', 'cial !@#$%^'],  // Special characters
+            ['من صالح هاشمی هستم هستم', 'من ', ' هستم', 'صالح هاشمی هستم'], // other languages
         ];
     }
 }

--- a/tests/StringHelperTest.php
+++ b/tests/StringHelperTest.php
@@ -763,4 +763,30 @@ final class StringHelperTest extends TestCase
 
         StringHelper::trim('string', "\xC3\x28");
     }
+
+    /**
+     * @dataProvider dataProviderFindBetween
+     */
+    public function testFindBetween(string $string, string $start, string $end, ?string $expectedResult): void
+    {
+        $this->assertSame($expectedResult, StringHelper::findBetween($string, $start, $end));
+    }
+
+    public function dataProviderFindBetween(): array
+    {
+        return [
+            ['hello world hello', ' hello', ' world', null],  // end before start
+            ['This is a sample string', ' is ', ' string', 'a sample'],  // normal case
+            ['startendstart', 'start', 'end', ''],  // end before start
+            ['startmiddleend', 'start', 'end', 'middle'],  // normal case
+            ['startend', 'start', 'end', ''],  // end immediately follows start
+            ['multiple start start end end', 'start ', ' end', 'start end'],  // multiple starts and ends
+            ['', 'start', 'end', null],  // empty string
+            ['no delimiters here', 'start', 'end', null],  // no start and end
+            ['start only', 'start', 'end', null], // start found but no end
+            ['end only', 'start', 'end', null], // end found but no start
+            ['spécial !@#$%^&*()', 'spé', '&*()', 'cial !@#$%^'],  // Special characters
+            ['من صالح هاشمی هستم', 'من ', ' هستم', 'صالح هاشمی'], // other languages
+        ];
+    }
 }


### PR DESCRIPTION
Implement `findBetween()`, `findBetweenFirst()` and `findBetweenLast()` methods to StringHelper to retrieve a substring that lies between two strings in different scenarios.

`findBetween()` method retrieves a substring that lies between the first occurrence of a specified start string and the last occurrence of a specified end string in the input string.

Tests are included.

### Usage
```php
$htmlContent = "<div class='content'>Hello World</div>";
$content = StringHelper::findBetween($htmlContent, "<div class='content'>", "</div>");
```
```php
$logData = "INFO: Start --- debug data --- End";
$debugData = StringHelper::findBetween($logData, "Start ---", "--- End");
```
```php
$htmlData = "<html><body><a href="https://example.com">Link</a></body></html>";
$link= StringHelper::findBetween($htmlData, '<a href="', '">');
```

`findBetweenFirst()`: Retrieves the first substring that lies between the specified start and end strings in the input string.
`findBetweenLast()`: Retrieves the last substring that lies between the specified start and end strings in the input string.

```php
$input = "[a][b][c]";
StringHelper::findBetween($input, "[", "]"); // Output: "a][b][c"
StringHelper::findBetweenFirst($input, "[", "]"); // Output: "a"
StringHelper::findBetweenLast($input, "[", "]"); // Output: "c"
```
