### PR TITLE
Add more specific psalm type for result of `StringHelper::base64UrlEncode()` method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 2.4.1 under development
 
-- no changes in this release.
+- Enh #128: Add more specific psalm type for result of `StringHelper::base64UrlEncode()` method (@vjik) 
 
 ## 2.4.0 December 22, 2023
 

--- a/src/StringHelper.php
+++ b/src/StringHelper.php
@@ -438,6 +438,10 @@ final class StringHelper
      * @param string $input The string to encode.
      *
      * @return string Encoded string.
+     *
+     * @psalm-template T as string
+     * @psalm-param T $input
+     * @psalm-return (T is non-empty-string ? non-empty-string : "")
      */
     public static function base64UrlEncode(string $input): string
     {

--- a/tests/StringHelperTest.php
+++ b/tests/StringHelperTest.php
@@ -252,13 +252,14 @@ final class StringHelperTest extends TestCase
         $this->assertEquals($output, $decoded);
     }
 
-    public function base64UrlEncodedStringsProvider(): array
+    public static function base64UrlEncodedStringsProvider(): array
     {
         return [
             'Regular string' => ['This is an encoded string', 'VGhpcyBpcyBhbiBlbmNvZGVkIHN0cmluZw=='],
             '? and _ characters' => ['subjects?_d=1', 'c3ViamVjdHM_X2Q9MQ=='],
             '> character' => ['subjects>_d=1', 'c3ViamVjdHM-X2Q9MQ=='],
             'Unicode' => ['Это закодированная строка', '0K3RgtC-INC30LDQutC-0LTQuNGA0L7QstCw0L3QvdCw0Y8g0YHRgtGA0L7QutCw'],
+            'empty string' => ['', ''],
         ];
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ❌
