### PR TITLE
Fix `StringHelper::parsePath()` for empty string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Bug #138: Explicitly mark nullable parameters (@ferrumfist)
 - Chg #140: Bump minimal required PHP version to 8.1 and minor refactoring (@vjik)
+- Bug #141: `StringHelper::parsePath()` for empty string returns path `['']` instead of `[]` before (@vjik)
 
 ## 2.5.0 January 19, 2025
 

--- a/src/StringHelper.php
+++ b/src/StringHelper.php
@@ -510,7 +510,7 @@ final class StringHelper
         }
 
         if ($path === '') {
-            return [];
+            return [''];
         }
 
         if (!str_contains($path, $delimiter)) {

--- a/src/StringHelper.php
+++ b/src/StringHelper.php
@@ -489,7 +489,7 @@ final class StringHelper
      *
      * @return string[]
      *
-     * @psalm-return list<string>
+     * @psalm-return non-empty-list<string>
      */
     public static function parsePath(
         string $path,

--- a/tests/StringHelperTest.php
+++ b/tests/StringHelperTest.php
@@ -443,8 +443,8 @@ final class StringHelperTest extends TestCase
             ['.key1.key2', '.', '\\', false, ['', 'key1', 'key2']],
             ['~key1~key2', '~', '\\', false, ['', 'key1', 'key2']],
 
-            ['', '.', '\\', false, []],
-            ['', '.', '\\', true, []],
+            ['', '.', '\\', false, ['']],
+            ['', '.', '\\', true, ['']],
         ];
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
