### PR TITLE
Check string on a valid UTF-8 in `StringHelper` trim methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Bug #138: Explicitly mark nullable parameters (@ferrumfist)
 - Chg #140: Bump minimal required PHP version to 8.1 and minor refactoring (@vjik)
+- Bug #142: Check string on a valid UTF-8 in `StringHelper` methods: `trim()`, `ltrim()` and `rtrim()` (@vjik)
 
 ## 2.5.0 January 19, 2025
 

--- a/src/StringHelper.php
+++ b/src/StringHelper.php
@@ -580,8 +580,13 @@ final class StringHelper
      */
     public static function trim(string|array $string, string $pattern = self::DEFAULT_WHITESPACE_PATTERN): string|array
     {
+        self::ensureUtf8String($string);
         self::ensureUtf8Pattern($pattern);
 
+        /**
+         * @var string|string[] `$string` is correct UTF-8 string and `$pattern` is correct (it should be passed
+         * already prepared), so `preg_replace` never returns `null`.
+         */
         return preg_replace("#^[$pattern]+|[$pattern]+$#uD", '', $string);
     }
 
@@ -603,8 +608,13 @@ final class StringHelper
      */
     public static function ltrim(string|array $string, string $pattern = self::DEFAULT_WHITESPACE_PATTERN): string|array
     {
+        self::ensureUtf8String($string);
         self::ensureUtf8Pattern($pattern);
 
+        /**
+         * @var string|string[] `$string` is correct UTF-8 string and `$pattern` is correct (it should be passed
+         * already prepared), so `preg_replace` never returns `null`.
+         */
         return preg_replace("#^[$pattern]+#u", '', $string);
     }
 
@@ -626,8 +636,13 @@ final class StringHelper
      */
     public static function rtrim(string|array $string, string $pattern = self::DEFAULT_WHITESPACE_PATTERN): string|array
     {
+        self::ensureUtf8String($string);
         self::ensureUtf8Pattern($pattern);
 
+        /**
+         * @var string|string[] `$string` is correct UTF-8 string and `$pattern` is correct (it should be passed
+         * already prepared), so `preg_replace` never returns `null`.
+         */
         return preg_replace("#[$pattern]+$#uD", '', $string);
     }
 
@@ -751,9 +766,9 @@ final class StringHelper
     }
 
     /**
-     * Ensure the input string is a valid UTF-8 string.
+     * Ensure the pattern is a valid UTF-8 string.
      *
-     * @param string $pattern The input string.
+     * @param string $pattern The pattern.
      *
      * @throws InvalidArgumentException
      */
@@ -761,6 +776,24 @@ final class StringHelper
     {
         if (!preg_match('##u', $pattern)) {
             throw new InvalidArgumentException('Pattern is not a valid UTF-8 string.');
+        }
+    }
+
+    /**
+     * Ensure the string is a valid UTF-8 string.
+     *
+     * @param string|array $string The string.
+     *
+     * @throws InvalidArgumentException
+     *
+     * @psalm-param string|string[] $string
+     */
+    private static function ensureUtf8String(string|array $string): void
+    {
+        foreach ((array) $string as $s) {
+            if (!preg_match('##u', $s)) {
+                throw new InvalidArgumentException('String is not a valid UTF-8 string.');
+            }
         }
     }
 }

--- a/src/StringHelper.php
+++ b/src/StringHelper.php
@@ -782,7 +782,7 @@ final class StringHelper
     /**
      * Ensure the string is a valid UTF-8 string.
      *
-     * @param string|array $string The string.
+     * @param array|string $string The string.
      *
      * @throws InvalidArgumentException
      *

--- a/tests/StringHelperTest.php
+++ b/tests/StringHelperTest.php
@@ -6,6 +6,7 @@ namespace Yiisoft\Strings\Tests;
 
 use InvalidArgumentException;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\TestWith;
 use PHPUnit\Framework\TestCase;
 use Yiisoft\Strings\StringHelper;
 
@@ -726,8 +727,49 @@ final class StringHelperTest extends TestCase
     public function testInvalidTrimPattern(): void
     {
         $this->expectException(InvalidArgumentException::class);
-
+        $this->expectExceptionMessage('Pattern is not a valid UTF-8 string.');
         StringHelper::trim('string', "\xC3\x28");
+    }
+
+    #[TestWith(["abc\xFF"])]
+    #[TestWith([['hello', "abc\xFF"]])]
+    public function testInvalidTrimString(string|array $string): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('String is not a valid UTF-8 string.');
+        StringHelper::trim($string);
+    }
+
+    public function testInvalidLtrimPattern(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Pattern is not a valid UTF-8 string.');
+        StringHelper::ltrim('string', "\xC3\x28");
+    }
+
+    #[TestWith(["abc\xFF"])]
+    #[TestWith([['hello', "abc\xFF"]])]
+    public function testInvalidLtrimString(string|array $string): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('String is not a valid UTF-8 string.');
+        StringHelper::ltrim($string);
+    }
+
+    public function testInvalidRtrimPattern(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Pattern is not a valid UTF-8 string.');
+        StringHelper::ltrim('string', "\xC3\x28");
+    }
+
+    #[TestWith(["abc\xFF"])]
+    #[TestWith([['hello', "abc\xFF"]])]
+    public function testInvalidRtrimString(string|array $string): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('String is not a valid UTF-8 string.');
+        StringHelper::rtrim($string);
     }
 
     #[DataProvider('dataProviderFindBetween')]


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
