### PR TITLE
Remove dead code in `StringHelper::truncateWordsByLength()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - New #156: Add `NumericHelper::trimDecimalZeros()` (@samdark, @vjik)
 - Enh #163: Explicitly import classes, functions, and constants in "use" sections (@vjik)
+- Enh #167: Remove dead code in `StringHelper::truncateWordsByLength()` (@vjik)
 
 ## 2.7.0 November 23, 2025
 

--- a/src/StringHelper.php
+++ b/src/StringHelper.php
@@ -382,10 +382,8 @@ final class StringHelper
         // Prefer not to break words if there's a space within the snippet.
         $lastSpace = mb_strrpos($truncated, ' ', 0, $encoding);
         if ($lastSpace !== false) {
-            $cut = rtrim(mb_substr($truncated, 0, $lastSpace, $encoding));
-            return $cut === ''
-                ? mb_substr($trimMarker, 0, $length, $encoding)
-                : $cut . $trimMarker;
+            return rtrim(mb_substr($truncated, 0, $lastSpace, $encoding))
+                . $trimMarker;
         }
 
         return $truncated . $trimMarker;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ❌

The branch existed to handle `$cut === ''`, returning `mb_substr($trimMarker, 0, $length, $encoding)`. But `$length > $markerLength` is already guaranteed by the earlier check on line 376, so that `mb_substr` call always returns `$trimMarker` in full — the same value the general branch produces via `$cut . $trimMarker` when `$cut` is empty. So the
  special-case branch never changed the output; it was redundant dead code duplicating the general case.

